### PR TITLE
Alterando Formato do Reponse ao Salvar no LocalStorage

### DIFF
--- a/scheduling_frontend/src/pages/Scheduling/index.js
+++ b/scheduling_frontend/src/pages/Scheduling/index.js
@@ -11,7 +11,10 @@ const Schedulings = () => {
     (async () => {
       try {
         const response = await axios.get("/");
-        window.localStorage.setItem("schedulings", JSON.stringify(response));
+        window.localStorage.setItem(
+          "schedulings",
+          JSON.stringify(response.data)
+        );
       } catch (error) {
         if (error.response) {
           showNotification({
@@ -22,7 +25,7 @@ const Schedulings = () => {
         }
       } finally {
         const data = JSON.parse(window.localStorage.getItem("schedulings"));
-        setSchedulings(data.data);
+        setSchedulings(data);
       }
     })();
   }, []);


### PR DESCRIPTION
O formato em que estava o salvamento no localStorage estava incompativel com o formato do dado sendo salvo pelo cadastro , por isso foi alterado